### PR TITLE
Fix height of rows with no drawn cells being ignored

### DIFF
--- a/src/common.typ
+++ b/src/common.typ
@@ -22,6 +22,11 @@
   int(0 <= x) - int(x < 0)
 }
 
+// Polyfill for array sum (.sum() is Typst 0.3.0+).
+#let array-sum(arr, zero: 0) = {
+  arr.fold(zero, (a, x) => a + x)
+}
+
 // get the types of things so we can compare with them
 // (0.2.0-0.7.0: they're strings; 0.8.0+: they're proper types)
 #let _array-type = type(())

--- a/src/renderer/old.typ
+++ b/src/renderer/old.typ
@@ -128,14 +128,10 @@
             let first-y = none
             let rightmost-x = none
 
-            let row-heights = 0pt
+            let row-heights = array-sum(rows.slice(start-y, end-y + 1), zero: 0pt)
 
             let first-row = true
             for row in group-rows {
-                if row.len() > 0 {
-                    let first-cell = row.at(0)
-                    row-heights += rows.at(first-cell.cell.y)
-                }
                 for cell-box in row {
                     let x = cell-box.cell.x
                     let y = cell-box.cell.y

--- a/tablex-test.typ
+++ b/tablex-test.typ
@@ -1040,3 +1040,22 @@ Combining em and pt (with a stroke object):
       vlinex(expand: -(2% + 2pt + 2em)),
     )
 )
+
+*Full-width rowspans displayed with the wrong height (Issue \#105)*
+
+#tablex(
+  columns: (auto, auto, auto, auto),
+  colspanx(4, rowspanx(3)[ONE]),
+  [TWO], [THREE], [FOUR], [FIVE],
+)
+
+#block(breakable: false)[
+    a
+
+    #tablex(
+    columns: 3,
+    colspanx(3, rowspanx(2)[a])
+    )
+
+    b
+]

--- a/tablex-test.typ
+++ b/tablex-test.typ
@@ -1059,3 +1059,30 @@ Combining em and pt (with a stroke object):
 
     b
 ]
+
+*More overlapping rowspans (Issue \#82)*
+
+#tablex(
+  auto-lines: false,
+  stroke: 1pt,
+  columns: (auto,auto,auto,auto),
+  align:center,
+  //hlinex(),
+  //vlinex(), vlinex(), vlinex(),vlinex(),
+  [Name], [He],[Rack],[Beschreibung],
+  hlinex(),
+  cellx(rowspan:2,align:center)["mt01"], cellx(fill: rgb("#b9edffff"), align: left,rowspan:2)[42],
+  cellx(rowspan:2,align:center)["WAT"],
+  //hlinex(),
+  cellx(rowspan:2,align:center)["Löschgasflasche"],
+  cellx(rowspan:2,align:center)["mt2"], cellx(fill: rgb("#b9edffff"), align: left,rowspan:2)[41],
+  cellx(rowspan:2,align:center)["WAT"],"test",
+  (""),"","","","",
+  cellx(rowspan:2,align:center)["mt3"], cellx(fill: rgb("#b9edffff"), align: left,rowspan:2)[40],
+  cellx(rowspan:2,align:center)["WAT"],"test",
+  "","","","","",
+  cellx(rowspan:2,align:center)["mt3"], cellx(fill: rgb("#b9edffff"), align: left,rowspan:2)[40],
+  cellx(rowspan:2,align:center)["WAT"],"test",
+  "","","","","",
+
+)


### PR DESCRIPTION
This bug was specific to the old renderer. The row heights were otherwise being calculated correctly.

- [x] Fixes #105 
- [x] Fixes #82
- [x] ~~Could affect #97~~ Nope, the bug is still there. Likely not a renderer bug then.