### PR TITLE
Fix extra rows always having `auto` height

### DIFF
--- a/src/tablex.typ
+++ b/src/tablex.typ
@@ -165,8 +165,11 @@
     let vlines = grid-info.vlines
     let items = grid-info.items
 
+    // When there are more rows than the user specified, we ensure they have
+    // the same size as the last specified row.
+    let last-row-size = if rows.len() == 0 { auto } else { rows.last() }
     for _ in range(grid-info.new-row-count - row-len) {
-        rows.push(auto)  // add new rows (due to extra cells)
+        rows.push(last-row-size)  // add new rows (due to extra cells)
     }
 
     let col-len = columns.len()

--- a/tablex-test.typ
+++ b/tablex-test.typ
@@ -1086,3 +1086,70 @@ Combining em and pt (with a stroke object):
   "","","","","",
 
 )
+
+*Extra rows should inherit the last row size (Issue \#97)*
+
+#tablex(
+  rows: 5pt,
+  cellx(x: 0, y: 1)[a\ a\ a\ a]
+)
+#v(4em)
+
+#[
+    #tablex(
+        align: center + horizon,
+        rows: 5mm,
+        columns: (7mm, 10mm, 23mm, 15mm, 10mm, 70mm, 5mm, 5mm, 5mm, 5mm, 12mm, 18mm),
+        ..range(5), cellx(rowspan: 3, colspan: 7)[],
+        ..range(5),
+        ..range(5),
+
+        ..range(5), rowspanx(5)[], colspanx(3)[], colspanx(2)[], [],
+        ..range(5), rowspanx(3)[], rowspanx(3)[], rowspanx(3)[], cellx(rowspan: 3, colspan: 2)[], rowspanx(3)[],
+        colspanx(2)[], ..range(3),
+        colspanx(2)[], ..range(3),
+        colspanx(2)[], ..range(3), colspanx(4)[], colspanx(2)[],
+
+        colspanx(2)[], ..range(3), rowspanx(3)[], cellx(rowspan: 3, colspan: 6)[],
+        colspanx(2)[], ..range(3),
+        colspanx(2)[], ..range(3),
+    )
+
+    #tablex(
+        align: center + horizon,
+        rows: 5mm,
+        columns: (7mm, 10mm, 23mm, 15mm, 10mm, 70mm, 5mm, 5mm, 5mm, 5mm, 12mm, 18mm),
+        ..range(5), cellx(x: 5, rowspan: 3, colspan: 7)[],
+        ..range(5),
+        ..range(5),
+
+        ..range(5), rowspanx(5)[], colspanx(3)[], colspanx(2)[], [],
+        ..range(5), rowspanx(3)[], rowspanx(3)[], rowspanx(3)[], cellx(rowspan: 3, colspan: 2)[], rowspanx(3)[],
+        colspanx(2)[], ..range(3),
+        colspanx(2)[], ..range(3),
+        colspanx(2)[], ..range(3), colspanx(4)[], colspanx(2)[],
+
+        colspanx(2)[], ..range(3), rowspanx(3)[], cellx(rowspan: 3, colspan: 6)[],
+        colspanx(2)[], ..range(3),
+        colspanx(2)[], ..range(3),
+    )
+
+    #tablex(
+        align: center + horizon,
+        rows: 5mm,
+        columns: (7mm, 10mm, 23mm, 15mm, 10mm, 70mm, 5mm, 5mm, 5mm, 5mm, 12mm, 18mm),
+        cellx(x: 5, rowspan: 3, colspan: 7)[],
+        ..range(5),
+        ..range(5),
+
+        ..range(5), rowspanx(5)[], colspanx(3)[], colspanx(2)[], [],
+        ..range(5), rowspanx(3)[], rowspanx(3)[], rowspanx(3)[], cellx(rowspan: 3, colspan: 2)[], rowspanx(3)[],
+        colspanx(2)[], ..range(3),
+        colspanx(2)[], ..range(3),
+        colspanx(2)[], ..range(3), colspanx(4)[], colspanx(2)[],
+
+        colspanx(2)[], ..range(3), rowspanx(3)[], cellx(rowspan: 3, colspan: 6)[],
+        colspanx(2)[], ..range(3),
+        colspanx(2)[], ..range(3),
+    )
+]


### PR DESCRIPTION
When N rows were specified, but the table ended up having M > N rows, all the M - N extra rows end up always having `auto` height, when, in reality, they should have the height of the last specified row height in the `rows` parameter (for example, if `rows: (25pt, 3pt)` was given, then they should have a height of 3pt).

Fixes #97