### PR TITLE
Create `fit-spans` option

### DIFF
--- a/src/common.typ
+++ b/src/common.typ
@@ -64,3 +64,32 @@
 #let array-sum(arr, zero: 0) = {
   arr.fold(zero, (a, x) => a + x)
 }
+
+// -- common validators --
+
+// Converts the 'fit-spans' argument to a (x: bool, y: bool) dictionary.
+// Optionally use a default dictionary to fill missing arguments with.
+// This is in common.typ as it is needed by grid.typ as well.
+#let validate-fit-spans(fit-spans, default: (x: false, y: false), error-prefix: none) = {
+  if type(error-prefix) == _str-type {
+    error-prefix = " " + error-prefix
+  } else {
+    error-prefix = ""
+  }
+  if type(fit-spans) == _bool-type {
+    fit-spans = (x: fit-spans, y: fit-spans)
+  }
+  if type(fit-spans) == _dict-type {
+    assert(fit-spans.len() > 0, message: "Tablex error:" + error-prefix + " 'fit-spans', if a dictionary, must not be empty.")
+    assert(fit-spans.keys().all(k => k in ("x", "y")), message: "Tablex error:" + error-prefix + " 'fit-spans', if a dictionary, must only have the keys x and y.")
+    assert(fit-spans.values().all(v => type(v) == _bool-type), message: "Tablex error:" + error-prefix + " keys 'x' and 'y' in the 'fit-spans' dictionary must be booleans (true/false).")
+    for key in ("x", "y") {
+      if key in default and key not in fit-spans {
+        fit-spans.insert(key, default.at(key))
+      }
+    }
+  } else {
+    panic("Tablex error:" + error-prefix + " Expected 'fit-spans' to be either a boolean or dictionary, found '" + str(type(fit-spans)) + "'")
+  }
+  fit-spans
+}

--- a/src/grid.typ
+++ b/src/grid.typ
@@ -287,13 +287,10 @@
         cell.content = content
 
         // resolve 'fit-spans' option for this cell
-        if "fit-spans" in cell {
-            if cell.fit-spans in (none, auto) {
-                // remove fit-spans when it should be inherited
-                let _ = cell.remove("fit-spans")
-            } else {
-                cell.fit-spans = validate-fit-spans(cell.fit-spans, default: fit-spans, error-prefix: "At cell (" + str(this-x) + ", " + str(this-y) + "):")
-            }
+        if "fit-spans" not in cell {
+            cell.fit-spans = auto
+        } else if cell.fit-spans != auto {
+            cell.fit-spans = validate-fit-spans(cell.fit-spans, default: fit-spans, error-prefix: "At cell (" + str(this-x) + ", " + str(this-y) + "):")
         }
 
         // up to which 'y' does this cell go

--- a/src/grid.typ
+++ b/src/grid.typ
@@ -147,7 +147,7 @@
 
 // Organize cells in a grid from the given items,
 // and also get all given lines
-#let generate-grid(items, x-limit: 0, y-limit: 0, map-cells: none) = {
+#let generate-grid(items, x-limit: 0, y-limit: 0, map-cells: none, fit-spans: none) = {
     // init grid as a matrix
     // y-limit  x   x-limit
     let grid = create-grid(x-limit, y-limit)
@@ -285,6 +285,16 @@
         }
 
         cell.content = content
+
+        // resolve 'fit-spans' option for this cell
+        if "fit-spans" in cell {
+            if cell.fit-spans in (none, auto) {
+                // remove fit-spans when it should be inherited
+                let _ = cell.remove("fit-spans")
+            } else {
+                cell.fit-spans = validate-fit-spans(cell.fit-spans, default: fit-spans, error-prefix: "At cell (" + str(this-x) + ", " + str(this-y) + "):")
+            }
+        }
 
         // up to which 'y' does this cell go
         let max-x = this-x + cell.colspan - 1

--- a/src/option-parsing.typ
+++ b/src/option-parsing.typ
@@ -272,6 +272,27 @@
     header-hlines-have-priority
 }
 
+// Converts the 'fit-spans' argument to a (x: bool, y: bool) dictionary.
+// Optionally use a default dictionary to fill missing arguments with.
+#let validate-fit-spans(fit-spans, default: (x: false, y: false)) = {
+    if type(fit-spans) == _bool-type {
+        fit-spans = (x: fit-spans, y: fit-spans)
+    }
+    if type(fit-spans) == _dict-type {
+        assert(fit-spans.len() > 0, message: "Tablex error: 'fit-spans', if a dictionary, must not be empty.")
+        assert(fit-spans.keys().all(k => k in ("x", "y")), message: "Tablex error: 'fit-spans', if a dictionary, must only have the keys x and y.")
+        assert(fit-spans.values().all(v => type(v) == _bool-type), message: "Tablex error: keys 'x' and 'y' in the 'fit-spans' dictionary must be booleans (true/false).")
+        for key in ("x", "y") {
+            if key in default and key not in fit-spans {
+                fit-spans.insert(key, default.at(key))
+            }
+        }
+    } else {
+        panic("Tablex error: Expected 'fit-spans' to be either a boolean or dictionary, found '" + str(type(fit-spans)) + "'")
+    }
+    fit-spans
+}
+
 #let validate-renderer(renderer) = {
     assert(renderer in ("old", "cetz"), message: "Tablex error: 'renderer' option must be either \"old\" or \"cetz\".")
 

--- a/src/option-parsing.typ
+++ b/src/option-parsing.typ
@@ -272,26 +272,7 @@
     header-hlines-have-priority
 }
 
-// Converts the 'fit-spans' argument to a (x: bool, y: bool) dictionary.
-// Optionally use a default dictionary to fill missing arguments with.
-#let validate-fit-spans(fit-spans, default: (x: false, y: false)) = {
-    if type(fit-spans) == _bool-type {
-        fit-spans = (x: fit-spans, y: fit-spans)
-    }
-    if type(fit-spans) == _dict-type {
-        assert(fit-spans.len() > 0, message: "Tablex error: 'fit-spans', if a dictionary, must not be empty.")
-        assert(fit-spans.keys().all(k => k in ("x", "y")), message: "Tablex error: 'fit-spans', if a dictionary, must only have the keys x and y.")
-        assert(fit-spans.values().all(v => type(v) == _bool-type), message: "Tablex error: keys 'x' and 'y' in the 'fit-spans' dictionary must be booleans (true/false).")
-        for key in ("x", "y") {
-            if key in default and key not in fit-spans {
-                fit-spans.insert(key, default.at(key))
-            }
-        }
-    } else {
-        panic("Tablex error: Expected 'fit-spans' to be either a boolean or dictionary, found '" + str(type(fit-spans)) + "'")
-    }
-    fit-spans
-}
+// 'validate-fit-spans' is needed by grid, and is thus in common.typ
 
 #let validate-renderer(renderer) = {
     assert(renderer in ("old", "cetz"), message: "Tablex error: 'renderer' option must be either \"old\" or \"cetz\".")

--- a/src/tablex.typ
+++ b/src/tablex.typ
@@ -114,11 +114,13 @@
 // the cell's contents are too tall; setting 'y' to 'true' causes auto rows to
 // ignore the size of rowspans.
 // This setting is mostly useful when you have a colspan or a rowspan spanning
-// tracks with fractional (1fr, 2fr, ...) size, which can the fractional track
-// to have less or even zero width, compromising all other cells in it. If
-// you're facing this problem, you may want experiment with setting this option
-// to 'true' or to '(y: true)'.
-// Note that this option can also be set in a per-cell basis.
+// tracks with fractional (1fr, 2fr, ...) size, which can cause the fractional
+// track to have less or even zero width, compromising all other cells in it.
+// If you're facing this problem, you may want experiment with setting this
+// option to '(y: true)' (if this is affecting columns) or 'true' (for rows
+// too).
+// Note that this option can also be set in a per-cell basis through cellx().
+// See its reference for more information.
 //
 // renderer: Choose the renderer you will use.
 // Must be either "old" or "cetz".

--- a/src/tablex.typ
+++ b/src/tablex.typ
@@ -259,7 +259,8 @@
             styles: styles,
             columns: columns, rows: rows,
             inset: inset, align: align,
-            gutter: gutter
+            gutter: gutter,
+            fit-spans: fit-spans
         )
 
         let columns = updated-cols-rows.columns

--- a/src/tablex.typ
+++ b/src/tablex.typ
@@ -183,7 +183,8 @@
     let grid-info = generate-grid(
         items,
         x-limit: col-len, y-limit: row-len,
-        map-cells: map-cells
+        map-cells: map-cells,
+        fit-spans: fit-spans
     )
 
     let table-grid = grid-info.grid

--- a/src/tablex.typ
+++ b/src/tablex.typ
@@ -98,6 +98,28 @@
 // 'none' if they're a position taken by a cell in a
 // colspan/rowspan.
 //
+// fit-spans: Determine if rowspans and colspans should fit within their
+// spanned 'auto'-sized tracks (columns and rows) instead of causing them to
+// expand based on the rowspan/colspan cell's size. (Most users of tablex
+// shouldn't have to change this option.)
+// Must either be a dictionary '(x: true/false, y: true/false)' or a boolean
+// true/false (which is converted to the (x: value, y: value) format with both
+// 'x' and 'y' being set to the same value; for instance, 'true' becomes
+// '(x: true, y: true)').
+// Setting 'x' to 'false' (the default) means that colspans will cause the last
+// (rightmost) auto column they span to expand if the cell's contents are too
+// long; setting 'x' to 'true' negates this, and auto columns will ignore the
+// size of colspans. Similarly, setting 'y' to 'false' (the default) means that
+// rowspans will cause the last (bottommost) auto row they span to expand if
+// the cell's contents are too tall; setting 'y' to 'true' causes auto rows to
+// ignore the size of rowspans.
+// This setting is mostly useful when you have a colspan or a rowspan spanning
+// tracks with fractional (1fr, 2fr, ...) size, which can the fractional track
+// to have less or even zero width, compromising all other cells in it. If
+// you're facing this problem, you may want experiment with setting this option
+// to 'true' or to '(y: true)'.
+// Note that this option can also be set in a per-cell basis.
+//
 // renderer: Choose the renderer you will use.
 // Must be either "old" or "cetz".
 // Defaults to "old".
@@ -126,6 +148,7 @@
     map-vlines: none,
     map-rows: none,
     map-cols: none,
+    fit-spans: false,
     renderer: "old",
     renderer-args: (:),
     ..items
@@ -138,6 +161,7 @@
     let map-vlines = validate-map-func(map-vlines)
     let map-rows = validate-map-func(map-rows)
     let map-cols = validate-map-func(map-cols)
+    let fit-spans = validate-fit-spans(fit-spans, default: (x: false, y: false))
     let renderer = validate-renderer(renderer)
     let renderer-args = validate-renderer-args(renderer-args, renderer: renderer)
 

--- a/src/tablex.typ
+++ b/src/tablex.typ
@@ -115,7 +115,7 @@
 // ignore the size of rowspans.
 // This setting is mostly useful when you have a colspan or a rowspan spanning
 // tracks with fractional (1fr, 2fr, ...) size, which can cause the fractional
-// track to have less or even zero width, compromising all other cells in it.
+// track to have less or even zero size, compromising all other cells in it.
 // If you're facing this problem, you may want experiment with setting this
 // option to '(x: true)' (if this is affecting columns) or 'true' (for rows
 // too, same as '(x: true, y: true)').

--- a/src/tablex.typ
+++ b/src/tablex.typ
@@ -117,8 +117,8 @@
 // tracks with fractional (1fr, 2fr, ...) size, which can cause the fractional
 // track to have less or even zero width, compromising all other cells in it.
 // If you're facing this problem, you may want experiment with setting this
-// option to '(y: true)' (if this is affecting columns) or 'true' (for rows
-// too).
+// option to '(x: true)' (if this is affecting columns) or 'true' (for rows
+// too, same as '(x: true, y: true)').
 // Note that this option can also be set in a per-cell basis through cellx().
 // See its reference for more information.
 //

--- a/src/types.typ
+++ b/src/types.typ
@@ -49,6 +49,7 @@
     rowspan: 1, colspan: 1,
     fill: auto, align: auto,
     inset: auto,
+    fit-spans: auto,
     render: none,
 ) = (
     tablex-dict-type: "cell",
@@ -58,6 +59,7 @@
     align: align,
     fill: fill,
     inset: inset,
+    fit-spans: fit-spans,
     render: render,
     x: x,
     y: y,

--- a/tablex-test.typ
+++ b/tablex-test.typ
@@ -1166,3 +1166,101 @@ Combining em and pt (with a stroke object):
 #tablex(columns: (auto, auto, auto, auto),
   [lorem_ipsum_dolor_sit_amet], [lorem], [lorem_ipsum_dolor_sit_amet_consectetur_adipisici], [lorem],
 )
+
+*Rowspans with 1fr and auto using 'fit-spans' (Issues \#56 and \#78)*
+
+#[
+#let unbreakable-tablex(..args) = block(breakable: false, tablex(..args))
+
+_For issue \#78_
+
+- Table is normal:
+
+    #unbreakable-tablex(
+        columns: (1fr, 1fr, auto, auto, auto),
+        [a], [b], [c], [d], [e],
+        cellx(colspan: 5)[#lorem(5)],
+        [a], [b], [c], [d], [e],
+        cellx(colspan: 2)[#lorem(10)], none, none, none,
+        [a], [b], [c], [d], [e],
+    )
+
+- Table has overlap:
+
+    #unbreakable-tablex(
+        columns: (1fr, 1fr, auto, auto, auto),
+        [a], [b], [c], [d], [e],
+        cellx(colspan: 5)[#lorem(5)],
+        [a], [b], [c], [d], [e],
+        cellx(colspan: 2)[#lorem(10)], none, none, none,
+        [a], [b], [c], [d], [e],
+        cellx(colspan: 3)[#lorem(15)], none, none,
+    )
+
+- Table no longer has overlap:
+
+    #unbreakable-tablex(
+        columns: (1fr, 1fr, auto, auto, auto),
+        fit-spans: (x: true),
+        [a], [b], [c], [d], [e],
+        cellx(colspan: 5)[#lorem(5)],
+        [a], [b], [c], [d], [e],
+        cellx(colspan: 2)[#lorem(10)], none, none, none,
+        [a], [b], [c], [d], [e],
+        cellx(colspan: 3)[#lorem(15)], none, none,
+    )
+
+_For issue \#56_
+
+- Table is normal:
+
+    #unbreakable-tablex(
+        columns: (auto, auto, 1fr),
+        [A], [BC], [D],
+        [A], [BC], [D],
+        [A], [BC], [D],
+        [A], [BC], [D]
+    )
+
+- Second column too large:
+
+    #unbreakable-tablex(
+        columns: (auto, auto, 1fr),
+        colspanx(3)[Hello world! Hello!],
+        [A], [BC], [D],
+        [A], [BC], [D],
+        [A], [BC], [D],
+        [A], [BC], [D]
+    )
+
+- Second column is now normal:
+
+    #unbreakable-tablex(
+        columns: (auto, auto, 1fr),
+        fit-spans: (x: true),
+        colspanx(3)[Hello world! Hello!],
+        [A], [BC], [D],
+        [A], [BC], [D],
+        [A], [BC], [D],
+        [A], [BC], [D]
+    )
+
+    #unbreakable-tablex(
+        columns: (auto, auto, 1fr),
+        fit-spans: true,
+        colspanx(3)[Hello world! Hello!],
+        [A], [BC], [D],
+        [A], [BC], [D],
+        [A], [BC], [D],
+        [A], [BC], [D]
+    )
+
+    #unbreakable-tablex(
+        columns: (auto, auto, 1fr),
+        colspanx(3, fit-spans: (x: true))[Hello world! Hello!],
+        [A], [BC], [D],
+        [A], [BC], [D],
+        [A], [BC], [D],
+        [A], [BC], [D]
+    )
+]


### PR DESCRIPTION
Helps with (potentially closes) #56 and #78.

The idea is to be able to specify `#tablex(fit-spans: (y: true))` in order to have colspans not affect auto columns' sizes.
That way, fractional columns won't be "squashed".

Consider the table below, from #78:

```typ
#tablex(
    columns: (1fr, 1fr, auto, auto, auto),
    [a], [b], [c], [d], [e],
    cellx(colspan: 5)[#lorem(5)],
    [a], [b], [c], [d], [e],
    cellx(colspan: 2)[#lorem(10)], none, none, none,
    [a], [b], [c], [d], [e],
    cellx(colspan: 3)[#lorem(15)], none, none,
)
```

The last row has a colspan which spans not only the two fractional columns, but also one `auto` column, causing the latter to expand more than it should (since `auto` columns are measured before fractional columns), leading to zero-width fractional columns:

![The first, second and third columns are overlapping](https://github.com/PgBiel/typst-tablex/assets/9021226/a11696c7-a4f0-4364-aa31-0db7ca1f159a)

Adding `fit-spans: (x: true)` causes the `auto` column to ignore the colspan's size, fixing the problem:

![The three first columns are not overlapping anymore](https://github.com/PgBiel/typst-tablex/assets/9021226/2d80cec4-f9c8-4031-a7de-e9ba1b7cbeec)