### PR TITLE
Remove `enumerate()` polyfill, use destructuring

### DIFF
--- a/src/col-row-size.typ
+++ b/src/col-row-size.typ
@@ -145,10 +145,7 @@
         gutter = frac-width * (gutter / 1fr)
     }
 
-    for i-size in frac-tracks {
-        let i = i-size.at(0)
-        let size = i-size.at(1)
-
+    for (i, size) in frac-tracks {
         tracks.at(i) = frac-width * (size / 1fr)
     }
 
@@ -161,11 +158,8 @@
     let cell-cols = range(cell.x, cell.x + cell.colspan)
     let last-auto-col = none
 
-    for i-col in columns.enumerate().filter(i-col => i-col.at(0) in cell-cols) {
-        let i = i-col.at(0)
-        let col = i-col.at(1)
-
-        if col == auto {
+    for (i, col) in columns.enumerate() {
+        if i in cell-cols and col == auto {
             last-auto-col = max-if-not-none(last-auto-col, i)
         }
     }
@@ -179,11 +173,8 @@
     let cell-rows = range(cell.y, cell.y + cell.rowspan)
     let last-auto-row = none
 
-    for i-row in rows.enumerate().filter(i-row => i-row.at(0) in cell-rows) {
-        let i = i-row.at(0)
-        let row = i-row.at(1)
-
-        if row == auto {
+    for (i, row) in rows.enumerate() {
+        if i in cell-rows and row == auto {
             last-auto-row = max-if-not-none(last-auto-row, i)
         }
     }
@@ -199,11 +190,8 @@
     let cell-cols = range(cell.x, cell.x + cell.colspan)
     let size = 0pt
 
-    for i-col in columns.enumerate().filter(i-col => i-col.at(0) in cell-cols) {
-        let i = i-col.at(0)
-        let col = i-col.at(1)
-
-        if type(col) == _length-type {
+    for (i, col) in columns.enumerate() {
+        if i in cell-cols and type(col) == _length-type {
             size += col
         }
     }
@@ -218,11 +206,8 @@
     let cell-rows = range(cell.y, cell.y + cell.rowspan)
     let size = 0pt
 
-    for i-row in rows.enumerate().filter(i-row => i-row.at(0) in cell-rows) {
-        let i = i-row.at(0)
-        let row = i-row.at(1)
-
-        if type(row) == _length-type {
+    for (i, row) in rows.enumerate() {
+        if i in cell-rows and type(row) == _length-type {
             size += row
         }
     }
@@ -236,10 +221,7 @@
     let auto-sizes = ()
     let new-columns = columns
 
-    for i-col in columns.enumerate() {
-        let i = i-col.at(0)
-        let col = i-col.at(1)
-
+    for (i, col) in columns.enumerate() {
         if col == auto {
             // max cell width
             let col-size = grid-get-column(grid, i)
@@ -451,10 +433,7 @@
     let auto-sizes = ()
     let new-rows = rows
 
-    for i-row in rows.enumerate() {
-        let i = i-row.at(0)
-        let row = i-row.at(1)
-
+    for (i, row) in rows.enumerate() {
         if row == auto {
             // max cell height
             let row-size = grid-get-row(grid, i)

--- a/src/col-row-size.typ
+++ b/src/col-row-size.typ
@@ -127,7 +127,7 @@
 // Calculate the size of fraction tracks (cols/rows) (1fr, 2fr, ...),
 // based on the remaining sizes (after fixed-size and auto columns)
 #let determine-frac-tracks(tracks, remaining: 0pt, gutter: none) = {
-    let frac-tracks = enumerate(tracks).filter(t => type(t.at(1)) == _fraction-type)
+    let frac-tracks = tracks.enumerate().filter(t => type(t.at(1)) == _fraction-type)
 
     let amount-frac = frac-tracks.fold(0, (acc, el) => acc + (el.at(1) / 1fr))
 
@@ -161,7 +161,7 @@
     let cell-cols = range(cell.x, cell.x + cell.colspan)
     let last-auto-col = none
 
-    for i-col in enumerate(columns).filter(i-col => i-col.at(0) in cell-cols) {
+    for i-col in columns.enumerate().filter(i-col => i-col.at(0) in cell-cols) {
         let i = i-col.at(0)
         let col = i-col.at(1)
 
@@ -179,7 +179,7 @@
     let cell-rows = range(cell.y, cell.y + cell.rowspan)
     let last-auto-row = none
 
-    for i-row in enumerate(rows).filter(i-row => i-row.at(0) in cell-rows) {
+    for i-row in rows.enumerate().filter(i-row => i-row.at(0) in cell-rows) {
         let i = i-row.at(0)
         let row = i-row.at(1)
 
@@ -199,7 +199,7 @@
     let cell-cols = range(cell.x, cell.x + cell.colspan)
     let size = 0pt
 
-    for i-col in enumerate(columns).filter(i-col => i-col.at(0) in cell-cols) {
+    for i-col in columns.enumerate().filter(i-col => i-col.at(0) in cell-cols) {
         let i = i-col.at(0)
         let col = i-col.at(1)
 
@@ -218,7 +218,7 @@
     let cell-rows = range(cell.y, cell.y + cell.rowspan)
     let size = 0pt
 
-    for i-row in enumerate(rows).filter(i-row => i-row.at(0) in cell-rows) {
+    for i-row in rows.enumerate().filter(i-row => i-row.at(0) in cell-rows) {
         let i = i-row.at(0)
         let row = i-row.at(1)
 
@@ -236,7 +236,7 @@
     let auto-sizes = ()
     let new-columns = columns
 
-    for i-col in enumerate(columns) {
+    for i-col in columns.enumerate() {
         let i = i-col.at(0)
         let col = i-col.at(1)
 
@@ -451,7 +451,7 @@
     let auto-sizes = ()
     let new-rows = rows
 
-    for i-row in enumerate(rows) {
+    for i-row in rows.enumerate() {
         let i = i-row.at(0)
         let row = i-row.at(1)
 

--- a/src/grid.typ
+++ b/src/grid.typ
@@ -335,7 +335,7 @@
     }
 
     // for missing cell positions: add empty cell
-    for index-item in enumerate(grid.items) {
+    for index-item in grid.items.enumerate() {
         let index = index-item.at(0)
         let item = index-item.at(1)
         if item == none {

--- a/src/grid.typ
+++ b/src/grid.typ
@@ -284,8 +284,7 @@
         let cell-positions = positions-spanned-by(cell, x: this-x, y: this-y, x-limit: x-limit, y-limit: none)
 
         for position in cell-positions {
-            let px = position.at(0)
-            let py = position.at(1)
+            let (px, py) = position
             let currently-there = grid-at(grid, px, py)
 
             if currently-there != none {
@@ -335,9 +334,7 @@
     }
 
     // for missing cell positions: add empty cell
-    for index-item in grid.items.enumerate() {
-        let index = index-item.at(0)
-        let item = index-item.at(1)
+    for (index, item) in grid.items.enumerate() {
         if item == none {
             grid.items.at(index) = new-empty-cell(grid, index: index)
         }

--- a/src/option-parsing.typ
+++ b/src/option-parsing.typ
@@ -154,7 +154,7 @@
                 panic("Tablex error: 'map-rows' returned " + str(cells.len()) + " cells, when it should have returned exactly " + str(original-cells.len()) + ".")
             }
 
-            for (i, cell) in enumerate(cells) {
+            for (i, cell) in cells.enumerate() {
                 let orig-cell = original-cells.at(i)
                 if not is-tablex-cell(orig-cell) {
                     // only modify non-occupied cells
@@ -201,7 +201,7 @@
                 panic("Tablex error: 'map-cols' returned " + str(cells.len()) + " cells, when it should have returned exactly " + str(original-cells.len()) + ".")
             }
 
-            for (i, cell) in enumerate(cells) {
+            for (i, cell) in cells.enumerate() {
                 let orig-cell = original-cells.at(i)
                 if not is-tablex-cell(orig-cell) {
                     // only modify non-occupied cells

--- a/src/renderer/old.typ
+++ b/src/renderer/old.typ
@@ -86,8 +86,7 @@
     let group-rows = row-group.rows
     let hlines = row-group.hlines
     let vlines = row-group.vlines
-    let start-y = row-group.y-span.at(0)
-    let end-y = row-group.y-span.at(1)
+    let (start-y, end-y) = row-group.y-span
 
     locate(loc => {
         // let old-page = latest-page-state.at(loc)

--- a/src/renderer/row-groups.typ
+++ b/src/renderer/row-groups.typ
@@ -69,8 +69,7 @@
             let row-group = this-row-group
 
             // get where the row starts and where it ends
-            let start-y = row-group.y-span.at(0)
-            let end-y = row-group.y-span.at(1)
+            let (start-y, end-y) = row-group.y-span
 
             let next-y = end-y + 1
 

--- a/src/utilities.typ
+++ b/src/utilities.typ
@@ -88,24 +88,6 @@
     calc.max(a, b)
 }
 
-// Backwards-compatible enumerate
-#let enumerate(arr) = {
-    if type(arr) != _array-type {
-        return arr
-    }
-
-    let new-arr = ()
-    let i = 0
-
-    for x in arr {
-        new-arr.push((i, x))
-
-        i += 1
-    }
-
-    new-arr
-}
-
 // Gets the topmost parent of a line.
 #let get-top-parent(line) = {
     let previous = none


### PR DESCRIPTION
We can use the built-in `array.enumerate()` function, since we support only Typst 0.2.0 and up.

Also use destructuring where possible.

Should squish a little tiny bit of perf.