### PR TITLE
Wraps calc.ceil and calc.floor in int

### DIFF
--- a/tablex.typ
+++ b/tablex.typ
@@ -244,7 +244,7 @@
         }
     }
 
-    let rows(len) = calc.ceil(len / col_len)
+    let rows(len) = int(calc.ceil(len / col_len))
 
     while rows(len) < max_explicit_y {
         len += col_len
@@ -311,13 +311,15 @@
 
     let grid_len = get-expected-grid-len(items, col_len: col_len)
 
-    let expected_rows = calc.ceil(grid_len / col_len)
+    let expected_rows = int(calc.ceil(grid_len / col_len))
 
     // more cells than expected => add rows
     if rows.len() < expected_rows {
         let missing_rows = expected_rows - rows.len()
 
-        rows += (rows.last(),) * missing_rows
+        for n in range(0, missing_rows) {
+          rows += (rows.last(),)
+        }
     }
 
     (columns: columns, rows: rows, items: ())
@@ -693,7 +695,7 @@
 // Gets the index of (x, y) in a grid's array.
 #let grid-index-at(x, y, grid: none, width: none) = {
     width = default-if-none(grid, (width: width)).width
-    width = calc.floor(width)
+    width = int(calc.floor(width))
     (y * width) + calc-mod(x, width)
 }
 
@@ -718,12 +720,12 @@
 
 // How many rows are in this grid? (Given its width)
 #let grid-count-rows(grid) = (
-    calc.floor(grid.items.len() / grid.width)
+    int(calc.floor(grid.items.len() / grid.width))
 )
 
 // Converts a grid array index to (x, y)
 #let grid-index-to-pos(grid, index) = (
-    (calc-mod(index, grid.width), calc.floor(index / grid.width))
+    (calc-mod(index, grid.width), int(calc.floor(index / grid.width)))
 )
 
 // Fetches an entire row of cells (all positions with the given y).


### PR DESCRIPTION
This module errors with the main branch of Typst due to <https://github.com/typst/typst/pull/4900>.

> # Breaking Changes
> 
> calc.floor(float), calc.ceil(float) and calc.trunc(float) now return floats instead of integers as the rounded float might be larger than the max integer (or less than the minimum integer).

This patch addresses the following errors.  In this case missing_rows is a float because it depends on expected_rows which is calculated with `calc.ceil`.  There were many issues like this one.

```
error: cannot multiply array with float
    ┌─ @local/tablex:0.0.8/tablex.typ:320:16
    │
320 │         rows += (rows.last(),) * missing_rows
    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```